### PR TITLE
Fixing nits suggested by Mahesh

### DIFF
--- a/draft-ietf-netmod-acl-extensions.md
+++ b/draft-ietf-netmod-acl-extensions.md
@@ -102,7 +102,7 @@ The document also defines IANA-maintained modules for ICMP types and IPv6 extens
 {{!RFC8519}} defines Access Control Lists (ACLs) as a
 user-ordered set of filtering rules. The model targets the
 configuration of the filtering behavior of a device. However, the
-model structure, as defined in {{!RFC8519}}, suffers from a set of limitations. 
+model structure, as defined in {{!RFC8519}}, suffers from a set of limitations.
 This document identifies these limitations and specifies an enhanced ACL structure,
 introducing augmentations to the ACL base model ({{sec-module}}).
 The motivation of such enhanced ACL structure is discussed in detail in {{ps}}.

--- a/draft-ietf-netmod-acl-extensions.md
+++ b/draft-ietf-netmod-acl-extensions.md
@@ -91,6 +91,7 @@ informative:
 RFC 8519 defines a YANG data model for Access Control Lists
 (ACLs). This document discusses a set of extensions that fix many of
 the limitations of the ACL model as initially defined in RFC 8519.
+Specifically, it introduces augmentations to the ACL base model to enhance its functionality and applicability.
 
 The document also defines IANA-maintained modules for ICMP types and IPv6 extension headers.
 
@@ -101,9 +102,10 @@ The document also defines IANA-maintained modules for ICMP types and IPv6 extens
 {{!RFC8519}} defines Access Control Lists (ACLs) as a
 user-ordered set of filtering rules. The model targets the
 configuration of the filtering behavior of a device. However, the
-model structure, as defined in {{!RFC8519}}, suffers from a set of limitations. This
-document describes these limitations and specifies an enhanced ACL
-structure ({{sec-module}}). The motivation of such enhanced ACL structure is discussed in detail in {{ps}}.
+model structure, as defined in {{!RFC8519}}, suffers from a set of limitations. 
+This document identifies these limitations and specifies an enhanced ACL structure, 
+introducing augmentations to the ACL base model ({{sec-module}}).
+The motivation of such enhanced ACL structure is discussed in detail in {{ps}}.
 
 When managing ACLs, it is common for network operators to group
 match elements in pre-defined sets. The consolidation into group matches
@@ -174,7 +176,7 @@ The meaning of the symbols in the tree diagrams is defined in
 In addition to the terms defined in {{!RFC8519}}, this document makes use of the following term:
 
 Defined set:
-: Refers to reusable description of one or multiple information elements (e.g., IP address, IP prefix, port number, or ICMP type).
+: Elements in a defined set typically share a logical purpose or function, such as IP address, IP prefixes, port number, or ICMP type.
 
 # Overall Structure of The Enhanced ACL Module
 
@@ -219,6 +221,9 @@ ICMP sets:
 Aliases:
 : An alias is defined by a combination of various parameters (e.g., IP prefix, protocol, port number, or VLAN {{IEEE802.1Qcp}}). Sets of aliases can be defined and referred to in ACL match criteria.
 
+Payload-based filtering:
+: Network traffic filtering technique that examines the data payload of packets, beyond just the header information, to identify, allow, or block traffic based on specific content or patterns within the payload.
+
 ## IPv6 Extension Headers
 
 The module can be used to manage ACLs that require matching against IPv6 extension headers {{!RFC8200}}. To that aim, a new IANA-maintained module for IPv6 extension header types "iana-ipv6-ext-types" is defined in this document.
@@ -239,7 +244,7 @@ Clients that support both 'ipv4-fragment' and 'flags' {{!RFC8519}} matching fiel
 
 Some transport protocols use existing protocols (e.g., TCP or UDP) as substrate. The match criteria for such protocols may rely upon the 'protocol' under 'l3', TCP/UDP match criteria, part of the TCP/UDP payload, or a combination thereof.
 
-A new feature, called 'match-on-payload', is defined in the document. This can be used, for example, for QUIC {{?RFC9000}} or for tunneling protocols. This feature requires configuring a data offset, a length, and a binary pattern to macth data against using a specified operator.
+A new feature, called 'match-on-payload', is defined in the document. This can be used, for example, for QUIC {{?RFC9000}} or for tunneling protocols. This feature requires configuring a data offset, a length, and a binary pattern to match data against using a specified operator.
 
 ## Match on MPLS Headers
 
@@ -458,7 +463,7 @@ IANA is requested to add this note to "ICMP Type Numbers" {{IANA-ICMPv4}}:
     When this registry is modified, the YANG module "iana-icmpv4-types"
     [IANA_ICMPv4_YANG_URL] must be updated as defined in RFC XXXX.
 
-IANA is requested to updated the "Reference" in the "ICMP Type Numbers" registry
+IANA is requested to update the "Reference" in the "ICMP Type Numbers" registry
 as follows:
 
 OLD:
@@ -517,7 +522,7 @@ IANA is requested to add this note to "ICMPv6 "type" Numbers" {{IANA-ICMPv6}}:
     When this registry is modified, the YANG module "iana-icmpv6-types"
     [IANA_ICMPv6_YANG_URL] must be updated as defined in RFC XXXX.
 
-IANA is requested to updated the "Reference" in the "ICMPv6 "type" Numbers" registry
+IANA is requested to update the "Reference" in the "ICMPv6 "type" Numbers" registry
 as follows:
 
 OLD:
@@ -576,7 +581,7 @@ IANA is requested to add this note to the "IPv6 Extension Header Types" registry
     When this registry is modified, the YANG module "iana-ipv6-ext-types"
     [IANA_IPV6_YANG_URL] must be updated as defined in RFC XXXX.
 
-IANA is requested to updated the "Reference" in the "IPv6 Extension Header Types" registry
+IANA is requested to update the "Reference" in the "IPv6 Extension Header Types" registry
 as follows:
 
 OLD:

--- a/draft-ietf-netmod-acl-extensions.md
+++ b/draft-ietf-netmod-acl-extensions.md
@@ -103,7 +103,7 @@ The document also defines IANA-maintained modules for ICMP types and IPv6 extens
 user-ordered set of filtering rules. The model targets the
 configuration of the filtering behavior of a device. However, the
 model structure, as defined in {{!RFC8519}}, suffers from a set of limitations. 
-This document identifies these limitations and specifies an enhanced ACL structure, 
+This document identifies these limitations and specifies an enhanced ACL structure,
 introducing augmentations to the ACL base model ({{sec-module}}).
 The motivation of such enhanced ACL structure is discussed in detail in {{ps}}.
 

--- a/draft-ietf-netmod-acl-extensions.md
+++ b/draft-ietf-netmod-acl-extensions.md
@@ -452,7 +452,7 @@ and sub-statements thereof, should be defined:
 :   Replicates the reference(s) from the registry with the
     title of the document(s) added.
 
-Unassigned or reserved values are not present in the module.
+Unassigned, reserved, or {{?RFC3692}}-style values are not present in the module.
 
 When the "iana-icmpv4-types" YANG module is updated, a new "revision"
 statement with a unique revision date must be added in front of the
@@ -511,7 +511,7 @@ and sub-statements thereof, should be defined:
 :   Replicates the reference(s) from the registry with the
     title of the document(s) added.
 
-Unassigned or reserved values are not present in the module.
+Unassigned, reserved, or private experimentation values are not present in the module.
 
 When the "iana-icmpv6-types" YANG module is updated, a new "revision"
 statement with a unique revision date must be added in front of the

--- a/draft-ietf-netmod-acl-extensions.md
+++ b/draft-ietf-netmod-acl-extensions.md
@@ -1098,7 +1098,7 @@ packets.  The following ACEs are defined (in this order):
 ~~~
 {: #example_5 title="An Example of Rate-Limit Incoming TCP SYNs (Message Body)."}
 
-# Acknowledgements
+# Acknowledgments
 {:numbered="false"}
 
 Many thanks to Jon Shallow and Miguel Cros for the review and comments to the document, including prior to publishing the document.


### PR DESCRIPTION
COMMENT:

"Abstract", paragraph 2
>    RFC 8519 defines a YANG data model for Access Control Lists (ACLs).
>    This document discusses a set of extensions that fix many of the
>    limitations of the ACL model as initially defined in RFC 8519.
> 
>    The document also defines IANA-maintained modules for ICMP types and
>    IPv6 extension headers.

This document provided important extensions to the base ACL YANG model defined in RFC8519.

However, nowhere in the document does it mention that these extensions augment the base model, except in the model itself. Reading the abstract and the introduction, a reader would be left wondering whether this model is replacing RFC 8519 or augmenting it. Can that be made clear?

Section 2, paragraph 4
>    Defined set:  Refers to reusable description of one or multiple
>       information elements (e.g., IP address, IP prefix, port number, or
>       ICMP type).

Is it just a description? A better way to define it would be to say:

Elements in a defined set typically share a logical purpose or function, such as IP address, IP prefixes, port number, or ICMP type.

Similarly definition of 'payload-based filtering' could be added to define the term or referenced if defined somewhere else.

Section 3.5, paragraph 1
>    The augmented ACL structure (Figure 1) includes new leafs
>    'ipv4-fragment' and 'ipv6-fragment' to better handle fragments.

The document comments that RFC8519 does not do a good job of handling fragments and that this document addresses that issue. It would help to explain how the model defined in the document allows for better handling of fragments. For example, describe how the combination of operator and fragment type eases fragment handling.

Section 4, paragraph 1
>    This model imports types from [RFC6991], [RFC8519], and [RFC8294].

Thanks first of all to Per for providing YANG doctor review comments. I also tend to agree with him that as a practice reference to RFC 9293, 4443, 3032, 792, and IEEE 802.1Q, IEEE 802.1ah need to be added here, even if they are referenced or mentioned elsewhere.

"Appendix E.", paragraph 1
>    This section provides a few examples to illustrate the use of the
>    enhanced ACL module ("ietf-acl-enh").

Thank you for providing examples along with the module. The added feature in this module is payload-based filtering. An example configuration reflecting that, say for HTTP headers, would greatly enhance the understanding of this module.

No reference entries found for these items, which were mentioned in the text:
 [RFC3692].

-------------------------------------------------------------------------------
NIT
-------------------------------------------------------------------------------

All comments below are about very minor potential issues that you may choose to
address in some way - or ignore - as you see fit. Some were flagged by
automated tools (via https://github.com/larseggert/ietf-reviewtool) so there
will likely be some false positives. There is no need to let me know what you
did with these suggestions.

Section 3.6, paragraph 2
>    A new feature, called 'match-on-payload', is defined in the document.
>    This can be used, for example, for QUIC [RFC9000] or for tunneling
>    protocols.  This feature requires configuring a data offset, a
>    length, and a binary pattern to macth data against using a specified
>    operator.

s/macth/match/

Section 6.3.1, paragraph 15
>    IANA is requested to updated the "Reference" in the "ICMP Type
>    Numbers" registry as follows:

s/updated/update/

Section 6.3.2, paragraph 15
>    IANA is requested to updated the "Reference" in the "ICMPv6 "type"
>    Numbers" registry as follows:

s/updated/update/

Section 6.3.3, paragraph 15
>    IANA is requested to updated the "Reference" in the "IPv6 Extension
>    Header Types" registry as follows:

s/updated/update/

Section 1.1, paragraph 10
> ixes, port number, or ICMP type. Similarly definition of 'payload-based filt
>                                  ^^^^^^^^^
A comma may be missing after the conjunctive/linking adverb "Similarly".

Section 4, paragraph 3
>  { base tcp-flag; description "Acknowledgment TCP flag bit."; reference "RFC
>                                ^^^^^^^^^^^^^^
Do not mix variants of the same word ("acknowledgment" and "acknowledgement")